### PR TITLE
Reduce git-secrets alert

### DIFF
--- a/.gitallowed
+++ b/.gitallowed
@@ -1,0 +1,2 @@
+# Yarn lock file having public URLs with hashes should be whitelisted
+yarn.lock


### PR DESCRIPTION
Strings in yarn.lock file contain public URLs with hashes are triggering a lot of false positive alerts. Manual inspection confirmed there is no sensitive data in this file. Will greatly appreciate if someone can help to merge this PR. Thank you very much.

@joh-m 